### PR TITLE
Update renovate configuration to match OPG standards

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,61 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    "schedule:daily",
-    ":pinAllExceptPeerDependencies",
-    ":automergeAll",
-    "npm:unpublishSafe",
-    "group:all"
+    "config:base"
   ],
-  "lockFileMaintenance": {
-    "enabled": true
+  "branchPrefix": "renovate-",
+  "commitMessageAction": "Renovate Update",
+  "labels": [
+    "Dependencies",
+    "Renovate"
+  ],
+  "prConcurrentLimit": 0,
+  "branchConcurrentLimit": 0,
+  "separateMultipleMajor": true,
+  "lockFileMaintenance": { "enabled": false },
+  "packageRules": [
+    {
+      "automerge": true,
+      "groupName": "Patch & Minor Updates",
+      "groupSlug": "all-minor-patch-updates",
+      "labels": [
+        "Dependencies",
+        "Renovate"
+      ],
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "prCreation": "immediate",
+      "prPriority": 4,
+      "stabilityDays": 3
+    }
+  ],
+  "major": {
+    "automerge": false,
+    "labels": [
+        "Dependencies",
+        "Renovate"
+    ],
+    "prCreation": "not-pending",
+    "stabilityDays": 3,
+    "prPriority": 0
+  },
+  "vulnerabilityAlerts": {
+    "groupName": "Security Alerts",
+    "labels": [
+      "Dependencies",
+      "Renovate"
+    ],
+    "dependencyDashboardApproval": false,
+    "stabilityDays": 0,
+    "rangeStrategy": "update-lockfile",
+    "commitMessagePrefix": "[SECURITY]",
+    "branchTopic": "{{{datasource}}}-{{{depName}}}-vulnerability",
+    "prCreation": "immediate",
+    "prPriority": 5
   }
 }


### PR DESCRIPTION
1. Ignore dependencies until 3 days old
2. Disable lockfile maintenance
3. Group patch/minor
4. Auto merge patch/minor
5. Individual PRs for Major
6. No automerge for Major PRs